### PR TITLE
Fix keystore download link cleanup timing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -444,7 +444,9 @@ export default function App(): JSX.Element {
         document.body.appendChild(a);
         a.click();
         document.body.removeChild(a);
-        URL.revokeObjectURL(url);
+        window.setTimeout(() => {
+          URL.revokeObjectURL(url);
+        }, 100);
         notify(
           "Keystore guardado. Mantén la contraseña y el archivo en un lugar seguro"
         );


### PR DESCRIPTION
## Summary
- defer revoking the generated keystore blob URL so the browser can finish initiating the download

## Testing
- npm install *(fails: registry access forbidden in container)*

------
https://chatgpt.com/codex/tasks/task_e_68caf4829a448322bae217025af239e2