### PR TITLE
Fix keystore download for MetaMask compatibility

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -344,7 +344,7 @@ export default function App(): JSX.Element {
         };
         const bundleStr = JSON.stringify(bundle, null, 2);
         localStorage.setItem("scol_keystore_json", bundleStr);
-        const blob = new Blob([bundleStr], { type: "application/json" });
+        const blob = new Blob([encJson], { type: "application/json" });
         const url = URL.createObjectURL(blob);
         const a = document.createElement("a");
         a.href = url;


### PR DESCRIPTION
## Summary
- update keystore download to use the raw encrypted JSON generated by ethers
- keep the extended metadata bundle only in localStorage for in-app reuse

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb26a1088c83229064a0b8f52fed70