### PR TITLE
Remove MVP suffix from wallet header

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -689,7 +689,7 @@ export default function App(): JSX.Element {
               className="h-10 w-auto"
             />
             <div>
-              <h1 className="text-2xl font-bold md:text-3xl">Scolcoin Web Wallet (MVP)</h1>
+              <h1 className="text-2xl font-bold md:text-3xl">Scolcoin Web Wallet</h1>
               <p className="text-sm text-slate-500">Non-custodial • EVM</p>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- remove the "(MVP)" suffix from the main wallet title so it simply reads "Scolcoin Web Wallet"

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cb303688ac83229c37edde7ea8a9b5